### PR TITLE
Exception when app menu button or title are null

### DIFF
--- a/flamingo/src/main/java/org/pushingpixels/flamingo/internal/ui/ribbon/BasicRibbonUI.java
+++ b/flamingo/src/main/java/org/pushingpixels/flamingo/internal/ui/ribbon/BasicRibbonUI.java
@@ -461,12 +461,17 @@ public abstract class BasicRibbonUI extends RibbonUI {
 
             int x = ltr ? ins.left : width - ins.right;
 
+            boolean isShowingAppMenuButton = (ribbon.getApplicationMenu() != null);
+
             // the application menu button width
-            FontMetrics fm = applicationMenuButton.getFontMetrics(applicationMenuButton.getFont());
-            int appMenuButtonWidth = fm.stringWidth(ribbon.getApplicationMenu().getTitle()) + 40;
+            int appMenuButtonWidth = 0;
+            if (isShowingAppMenuButton) {
+                String title = ribbon.getApplicationMenu().getTitle();
+                FontMetrics fm = applicationMenuButton.getFontMetrics(applicationMenuButton.getFont());
+                appMenuButtonWidth = (title != null ? fm.stringWidth(title) : 0) + 40;
+            }
 
             x = ltr ? x + 2 : x - 2;
-            boolean isShowingAppMenuButton = (ribbon.getApplicationMenu() != null);
             if (isShowingAppMenuButton) {
                 x = ltr ? x + appMenuButtonWidth + 2 : x - appMenuButtonWidth - 2;
             }
@@ -486,7 +491,7 @@ public abstract class BasicRibbonUI extends RibbonUI {
             taskToggleButtonsStrip.setPreferredSize(null);
 
             int fullPreferredContentWidth = ins.left + ins.right + 2
-                    + (isShowingAppMenuButton ? appMenuButtonWidth : 0)
+                    + appMenuButtonWidth
                     + ((anchoredButtons.getComponentCount() > 0)
                     ? (anchoredButtonsExpandedWidth + tabButtonGap)
                     : 0)


### PR DESCRIPTION
The width of he app menu button is calculated before checking if it's null, so an exception is thrown if it's so.
I've assumed that, if the title is null too, the button is displayed like if it was an empty String (currently fails also).