### PR TITLE
Improved german translation

### DIFF
--- a/substance/src/main/resources/org/pushingpixels/substance/internal/resources/Labels_de.properties
+++ b/substance/src/main/resources/org/pushingpixels/substance/internal/resources/Labels_de.properties
@@ -2,7 +2,7 @@
  
 SystemMenu.close=Schlie\u00DFen
 
-SystemMenu.iconify=Ikonifizieren
+SystemMenu.iconify=Minimieren
 
 SystemMenu.restore=Wiederherstellen
 


### PR DESCRIPTION
Changed tooltip text from the awkward sounding "Ikonifizieren" to the generally used term "Minimieren"