### PR TITLE
Fix HiDPI compatibility for recent JDK

### DIFF
--- a/neon/src/main/java/org/pushingpixels/neon/internal/contrib/intellij/UIUtil.java
+++ b/neon/src/main/java/org/pushingpixels/neon/internal/contrib/intellij/UIUtil.java
@@ -107,7 +107,7 @@ public class UIUtil {
                 return devicesScaleFactorCacheMap.get(device);
             }
 
-            double result = LookUtils.IS_JAVA_9 || LookUtils.IS_JAVA_10 || LookUtils.IS_JAVA_11 ?
+            double result = LookUtils.getJavaMajorVersion() >= 9 ?
                     getScaleFactorModern(device) : getScaleFactorLegacy(device);
 
             devicesScaleFactorCacheMap.put(device, result);

--- a/neon/src/main/java/org/pushingpixels/neon/internal/contrib/jgoodies/looks/LookUtils.java
+++ b/neon/src/main/java/org/pushingpixels/neon/internal/contrib/jgoodies/looks/LookUtils.java
@@ -193,6 +193,22 @@ public final class LookUtils {
 			return defaultValue;
 		}
 	}
+	
+    /**
+     * Get the Java current major version. The old prefix "1." is removed 
+     * (e.g. 1.8 => 8, 11 => 11)
+     * 
+     * @return the major version of the running JRE
+     */
+    public static int getJavaMajorVersion() {
+        // Handle new version from Java 9
+        String jvmVersionString = JAVA_SPEC_VERSION;
+        int verIndex = jvmVersionString.indexOf("1."); //$NON-NLS-1$
+        if (verIndex >= 0) {
+            jvmVersionString = jvmVersionString.substring(verIndex + 2);
+        }
+        return Integer.parseInt(jvmVersionString);
+    }
 
 	// Private Helper Methods ***********************************************
 

--- a/neon/src/main/java/org/pushingpixels/neon/internal/font/DefaultMacFontPolicy.java
+++ b/neon/src/main/java/org/pushingpixels/neon/internal/font/DefaultMacFontPolicy.java
@@ -45,7 +45,7 @@ public class DefaultMacFontPolicy implements FontPolicy {
 	@Override
 	public FontSet getFontSet(UIDefaults table) {
 	    String fontFamily = "Lucida Grande";
-	    if (LookUtils.IS_JAVA_9 || LookUtils.IS_JAVA_10 || LookUtils.IS_JAVA_11) {
+	    if (LookUtils.getJavaMajorVersion() >= 9) {
 	        if (LookUtils.IS_OS_MAC_EL_CAPITAN_OR_LATER) {
 	            fontFamily = ".SF NS Text";
 	        } else if (LookUtils.IS_OS_MAC_YOSEMITE) {


### PR DESCRIPTION
A more flexible method to check the Java version as every 6 months a new version is released. JDK 12 is already available.