### PR TITLE
 Included support to single thread model on TimelineEngine

### DIFF
--- a/demos/trident-demo/src/main/java/org/pushingpixels/demo/trident/HelloWorldSingleThread.java
+++ b/demos/trident-demo/src/main/java/org/pushingpixels/demo/trident/HelloWorldSingleThread.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2005-2019 Trident Kirill Grouchnikov. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *  o Redistributions of source code must retain the above copyright notice, 
+ *    this list of conditions and the following disclaimer. 
+ *     
+ *  o Redistributions in binary form must reproduce the above copyright notice, 
+ *    this list of conditions and the following disclaimer in the documentation 
+ *    and/or other materials provided with the distribution. 
+ *     
+ *  o Neither the name of Trident Kirill Grouchnikov nor the names of 
+ *    its contributors may be used to endorse or promote products derived 
+ *    from this software without specific prior written permission. 
+ *     
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+package org.pushingpixels.demo.trident;
+
+import org.pushingpixels.trident.Timeline;
+import org.pushingpixels.trident.TimelineEngineAccessor;
+
+public class HelloWorldSingleThread {
+    private float value;
+
+    public void setValue(float newValue) {
+        System.out.println(this.value + " -> " + newValue);
+        this.value = newValue;
+    }
+
+    public static void main(String[] args) {
+
+        TimelineEngineAccessor timelineEngineAccessor = TimelineEngineAccessor.getInstance();
+
+        HelloWorldSingleThread helloWorldSingleThread = new HelloWorldSingleThread();
+
+        Timeline.builder(helloWorldSingleThread)
+                .addPropertyToInterpolate("value", 0.0f, 1.0f)
+                .play();
+
+        while (helloWorldSingleThread.value < 1.0f) {
+            timelineEngineAccessor.pulse();
+            try {
+                Thread.sleep(40);
+            } catch (Exception exc) {
+            }
+        }
+
+    }
+}

--- a/trident/src/main/java/org/pushingpixels/trident/TimelineEngine.java
+++ b/trident/src/main/java/org/pushingpixels/trident/TimelineEngine.java
@@ -741,7 +741,7 @@ class TimelineEngine {
      * @return The animator thread.
      */
     private TridentAnimationThread getAnimatorThread() {
-        if (TridentConfig.getInstance().getPulseSource() != null && this.animatorThread == null) {
+        if (this.animatorThread == null && TridentConfig.getInstance().getPulseSource() != null) {
             this.animatorThread = new TridentAnimationThread();
             this.animatorThread.start();
         }
@@ -754,7 +754,7 @@ class TimelineEngine {
      * @return The animator thread.
      */
     private TimelineCallbackThread getCallbackThread() {
-        if (TridentConfig.getInstance().getPulseSource() != null && this.callbackThread == null) {
+        if (this.callbackThread == null && TridentConfig.getInstance().getPulseSource() != null) {
             this.callbackThread = new TimelineCallbackThread();
             this.callbackThread.start();
         }

--- a/trident/src/main/java/org/pushingpixels/trident/TimelineEngine.java
+++ b/trident/src/main/java/org/pushingpixels/trident/TimelineEngine.java
@@ -153,7 +153,7 @@ class TimelineEngine {
      */
     TridentAnimationThread animatorThread;
 
-    private BlockingQueue<Runnable> callbackQueue;
+    BlockingQueue<Runnable> callbackQueue;
 
     private TimelineCallbackThread callbackThread;
 
@@ -212,7 +212,6 @@ class TimelineEngine {
         this.runningScenarios = new HashSet<TimelineScenario>();
 
         this.callbackQueue = new LinkedBlockingQueue<Runnable>();
-        this.callbackThread = this.getCallbackThread();
     }
 
     /**
@@ -739,7 +738,7 @@ class TimelineEngine {
      * @return The animator thread.
      */
     private TridentAnimationThread getAnimatorThread() {
-        if (this.animatorThread == null) {
+        if (TridentConfig.getInstance().getPulseSource() != null && this.animatorThread == null) {
             this.animatorThread = new TridentAnimationThread();
             this.animatorThread.start();
         }
@@ -752,7 +751,7 @@ class TimelineEngine {
      * @return The animator thread.
      */
     private TimelineCallbackThread getCallbackThread() {
-        if (this.callbackThread == null) {
+        if (TridentConfig.getInstance().getPulseSource() != null && this.callbackThread == null) {
             this.callbackThread = new TimelineCallbackThread();
             this.callbackThread.start();
         }

--- a/trident/src/main/java/org/pushingpixels/trident/TimelineEngine.java
+++ b/trident/src/main/java/org/pushingpixels/trident/TimelineEngine.java
@@ -498,6 +498,7 @@ class TimelineEngine {
             System.out.println("Scheduling callback runnable for " + oldState.name() + " to "
                     + newState.name() + " on timeline " + timeline.id);
         }
+        getCallbackThread();
         this.callbackQueue.add(callbackRunnable);
     }
 
@@ -519,11 +520,13 @@ class TimelineEngine {
                 timeline.callbackChain.onTimelinePulse(durationFraction, timelinePosition);
             }
         };
+        getCallbackThread();
         this.callbackQueue.add(callbackRunnable);
     }
 
     private void callbackCallTimelineScenarioEnded(final TimelineScenario timelineScenario) {
         Runnable callbackRunnable = () -> timelineScenario.callback.onTimelineScenarioDone();
+        getCallbackThread();
         this.callbackQueue.offer(callbackRunnable);
     }
 

--- a/trident/src/main/java/org/pushingpixels/trident/TimelineEngineAccessor.java
+++ b/trident/src/main/java/org/pushingpixels/trident/TimelineEngineAccessor.java
@@ -29,7 +29,6 @@
  */
 package org.pushingpixels.trident;
 
-
 public final class TimelineEngineAccessor {
 
     private static TimelineEngineAccessor config;

--- a/trident/src/main/java/org/pushingpixels/trident/TimelineEngineAccessor.java
+++ b/trident/src/main/java/org/pushingpixels/trident/TimelineEngineAccessor.java
@@ -31,7 +31,7 @@ package org.pushingpixels.trident;
 
 public final class TimelineEngineAccessor {
 
-    private static TimelineEngineAccessor config;
+    private static TimelineEngineAccessor instance;
     private final TimelineEngine engine;
 
     private TimelineEngineAccessor() {
@@ -51,11 +51,11 @@ public final class TimelineEngineAccessor {
     }
 
     public static synchronized TimelineEngineAccessor getInstance() {
-        if (config == null) {
+        if (instance == null) {
             TridentConfig.getInstance().setPulseSource(null);
             TimelineEngine.getInstance().lastIterationTimeStamp  = System.currentTimeMillis();
-            config = new TimelineEngineAccessor();
+            instance = new TimelineEngineAccessor();
         }
-        return config;
+        return instance;
     }
 }

--- a/trident/src/main/java/org/pushingpixels/trident/TimelineEngineAccessor.java
+++ b/trident/src/main/java/org/pushingpixels/trident/TimelineEngineAccessor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2005-2019 Trident Kirill Grouchnikov. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  o Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  o Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  o Neither the name of Trident Kirill Grouchnikov nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.pushingpixels.trident;
+
+
+public final class TimelineEngineAccessor {
+
+    private static TimelineEngineAccessor config;
+    private final TimelineEngine engine;
+
+    private TimelineEngineAccessor() {
+        this.engine = TimelineEngine.getInstance();
+    }
+
+    public void pulse() {
+        engine.updateTimelines();
+        Runnable callback;
+        while ((callback = engine.callbackQueue.poll()) != null) {
+            try {
+                callback.run();
+            } catch (Throwable t) {
+                t.printStackTrace();
+            }
+        }
+    }
+
+    public static synchronized TimelineEngineAccessor getInstance() {
+        if (config == null) {
+            TridentConfig.getInstance().setPulseSource(null);
+            TimelineEngine.getInstance().lastIterationTimeStamp  = System.currentTimeMillis();
+            config = new TimelineEngineAccessor();
+        }
+        return config;
+    }
+}


### PR DESCRIPTION
If PulseSource is null, don't create threads.
Included a new class to invoke "pulse" of TimelineEngine by outside:
* Update timelines.
* Run callbacks.