### PR TITLE
Creating a JRibbonFrame wihout an application menu causes an NPE

### DIFF
--- a/flamingo/src/main/java/org/pushingpixels/flamingo/internal/ui/ribbon/BasicRibbonUI.java
+++ b/flamingo/src/main/java/org/pushingpixels/flamingo/internal/ui/ribbon/BasicRibbonUI.java
@@ -467,12 +467,15 @@ public abstract class BasicRibbonUI extends RibbonUI {
 
             // the application menu button width
             boolean isShowingAppMenuButton = (ribbon.getApplicationMenuProjection() != null);
-            FontMetrics fm = SubstanceMetricsUtilities.getFontMetrics(
-                    applicationMenuButton.getFont());
-            int appMenuButtonWidth = isShowingAppMenuButton
-                    ? fm.stringWidth(ribbon.getApplicationMenuCommandProjection()
-                    .getContentModel().getText()) + 40
-                    : 0;
+            
+            int appMenuButtonWidth = 0;
+            if (isShowingAppMenuButton) {
+                FontMetrics fm = SubstanceMetricsUtilities.getFontMetrics(
+                        applicationMenuButton.getFont());
+                
+                appMenuButtonWidth = fm.stringWidth(ribbon.getApplicationMenuCommandProjection()
+                    .getContentModel().getText()) + 40;
+            }
 
             x = ltr ? x + 2 : x - 2;
             if (isShowingAppMenuButton) {
@@ -552,7 +555,6 @@ public abstract class BasicRibbonUI extends RibbonUI {
                     applicationMenuButton.setBounds(x + 2, y + 1, appMenuButtonWidth,
                             taskToggleButtonHeight - 1);
                 }
-            } else {
                 applicationMenuButton.setVisible(false);
             }
 

--- a/flamingo/src/main/java/org/pushingpixels/flamingo/internal/ui/ribbon/BasicRibbonUI.java
+++ b/flamingo/src/main/java/org/pushingpixels/flamingo/internal/ui/ribbon/BasicRibbonUI.java
@@ -555,7 +555,6 @@ public abstract class BasicRibbonUI extends RibbonUI {
                     applicationMenuButton.setBounds(x + 2, y + 1, appMenuButtonWidth,
                             taskToggleButtonHeight - 1);
                 }
-                applicationMenuButton.setVisible(false);
             }
 
             TaskToggleButtonsHostPanel taskToggleButtonsHostPanel =


### PR DESCRIPTION
I'm not sure if this is related to #78 or not, but if you create an instance of `JRibbonFrame` and don't set an app menu then this triggers an NPE in the latest 2.0.1 release of Flamingo as well as 2.5-SNAPSHOT on line 471

https://github.com/kirill-grouchnikov/radiance/blob/1c9325c62873c32444d493d667d45800d9621d1c/flamingo/src/main/java/org/pushingpixels/flamingo/internal/ui/ribbon/BasicRibbonUI.java#L471

The problem seems to be that the `applicationMenuButton` is only initialized if it is going to be shown (which makes sense)

https://github.com/kirill-grouchnikov/radiance/blob/1c9325c62873c32444d493d667d45800d9621d1c/flamingo/src/main/java/org/pushingpixels/flamingo/internal/ui/ribbon/BasicRibbonUI.java#L141

This PR fixes two places in `JRibbonFrame` where the `applicationMenuButton` was being accessed even though it was null. Testing seems to suggest that this fully fixes the NPE (or at least I can now create a `JRibbonFrame` without an application menu).