### PR TITLE
build.gradle: drop JDK version enforement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,16 +69,9 @@ allprojects {
 
     // Configure Java compilation for all the projects
     tasks.withType(JavaCompile) {
-        // enforce Java 9 as the source + target + compile time level
         def javaVersion = JavaVersion.VERSION_1_9
         sourceCompatibility = javaVersion
         targetCompatibility = javaVersion
-
-        compileJava.doFirst {
-            if (JavaVersion.current() != javaVersion)
-                throw new IllegalStateException("Compiler version mismatch; required is "
-                        + javaVersion + ", but using " + JavaVersion.current());
-        }
 
         // flag all usage of deprecated APIs as errors
         options.deprecation = true


### PR DESCRIPTION
Java 9 is EOL. Please drop the version enforcement altogether. The Java compiler should take care that `targetCompatibility` is respected anyways.