### PR TITLE
Use floats for GeneralPath.moveTo/lineTo/curveTo

### DIFF
--- a/photon/src/main/java/org/pushingpixels/photon/api/transcoder/SvgBaseTranscoder.java
+++ b/photon/src/main/java/org/pushingpixels/photon/api/transcoder/SvgBaseTranscoder.java
@@ -291,23 +291,23 @@ abstract class SvgBaseTranscoder {
             switch (type) {
                 case PathIterator.SEG_CUBICTO:
                     printWriterManager.println(languageRenderer.getObjectNoNull("generalPath" + suffix)
-                            + ".curveTo(" + coords[0] + ", " + coords[1] + ", " + coords[2] + ", "
-                            + coords[3] + ", " + coords[4] + ", " + coords[5] + ")"
+                            + ".curveTo(" + coords[0] + "f, " + coords[1] + "f, " + coords[2] + "f, "
+                            + coords[3] + "f, " + coords[4] + "f, " + coords[5] + "f)"
                             + languageRenderer.getStatementEnd());
                     break;
                 case PathIterator.SEG_QUADTO:
                     printWriterManager.println(languageRenderer.getObjectNoNull("generalPath" + suffix)
-                            + ".quadTo(" + coords[0] + ", " + coords[1] + ", " + coords[2] + ", "
-                            + coords[3] + ")" + languageRenderer.getStatementEnd());
+                            + ".quadTo(" + coords[0] + "f, " + coords[1] + "f, " + coords[2] + "f, "
+                            + coords[3] + "f)" + languageRenderer.getStatementEnd());
                     break;
                 case PathIterator.SEG_MOVETO:
                     printWriterManager.println(languageRenderer.getObjectNoNull("generalPath" + suffix)
-                            + ".moveTo(" + coords[0] + ", " + coords[1] + ")"
+                            + ".moveTo(" + coords[0] + "f, " + coords[1] + "f)"
                             + languageRenderer.getStatementEnd());
                     break;
                 case PathIterator.SEG_LINETO:
                     printWriterManager.println(languageRenderer.getObjectNoNull("generalPath" + suffix)
-                            + ".lineTo(" + coords[0] + ", " + coords[1] + ")"
+                            + ".lineTo(" + coords[0] + "f, " + coords[1] + "f)"
                             + languageRenderer.getStatementEnd());
                     break;
                 case PathIterator.SEG_CLOSE:


### PR DESCRIPTION
The double variants of the GeneralPath methods perform the
transformation to float anyways.

This reduces the size of the .class files of @JOSM's images from 10_042_499 to 9_143_795 bytes.