### PR TITLE
feature 407: new methods in interface RadianceIcon + rotate in templ

### DIFF
--- a/common/src/main/java/org/pushingpixels/radiance/common/api/icon/RadianceIcon.java
+++ b/common/src/main/java/org/pushingpixels/radiance/common/api/icon/RadianceIcon.java
@@ -40,8 +40,40 @@ import java.awt.image.BufferedImage;
  * resizing and color filtering.
  * 
  * @author Kirill Grouchnikov
+ * @author EUG https://github.com/homebeaver (rotation)
  */
-public interface RadianceIcon extends Icon {
+public interface RadianceIcon extends Icon, SwingConstants  {
+	
+	/**
+	 * A hint to rotate the icon when painting
+	 * 
+	 * @param theta the angle of rotation in radians, zero means no rotation
+	 */
+	// a default is necessary for icons generated before this feature was active
+	default void setRotation(double theta) {}
+	default double getRotation() {
+		return 0d; // no rotation
+	}
+	/**
+	 * A hint to rotate the icon to a direction.
+	 * <p> The icon is aligned to {@code NORTH} per default, 
+	 * so rotate direction {@code NORTH_EAST} means rotating 45° right
+	 * and {@code WEST} means rotating 90° left.
+	 * 
+	 * @param direction Compass-direction, use {@code SwingConstants} {@code NORTH}, {@code NORTH_EAST} etc
+	 * 
+	 * @see #setRotation(double)
+	 */
+	default void setRotation(int direction) {
+        if(direction>=NORTH && direction<=SOUTH) {
+        	this.setRotation(Math.PI*(direction-1)/4); // rotation to right, includes NORTH (no rotation)
+        } else if(direction>=SOUTH_WEST && direction<=NORTH_WEST) {
+        	this.setRotation(Math.PI*(direction-9)/4); // rotation to left
+        } else {
+            setRotation(0d); // no rotation for invalid directions
+        }
+	}
+
 	/**
 	 * Changes the dimension of <code>this</code> icon.
 	 * 

--- a/tools/svg-transcoder/src/main/resources/org/pushingpixels/radiance/tools/svgtranscoder/api/java/SvgTranscoderTemplateRadiance.templ
+++ b/tools/svg-transcoder/src/main/resources/org/pushingpixels/radiance/tools/svgtranscoder/api/java/SvgTranscoderTemplateRadiance.templ
@@ -27,6 +27,14 @@ public class TOKEN_CLASSNAME implements RadianceIcon {
     private RadianceIcon.ColorFilter colorFilter = null;
     private Stack<AffineTransform> transformsStack = new Stack<>();
 
+    private double theta = 0;
+    public void setRotation(double theta) {
+    	this.theta = theta;
+    }    
+    public double getRotation() {
+		return theta;
+	}
+
     TOKEN_RASTER_CODE
 
 	TOKEN_PAINTING_CODE
@@ -137,6 +145,9 @@ public class TOKEN_CLASSNAME implements RadianceIcon {
 				RenderingHints.VALUE_ANTIALIAS_ON);
         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+        if(getRotation()!=0) {
+            g2d.rotate(getRotation(), x+width/2, y+height/2);
+        }
 		g2d.translate(x, y);
 
         double coef1 = (double) this.width / getOrigWidth();


### PR DESCRIPTION
https://github.com/kirill-grouchnikov/radiance/issues/407

- a default in interface `RadianceIcon` is necessary for icons generated before this feature was active
- in java templ I generate the implementation for the methods `setRotation` and `getRotation` and do the rotation